### PR TITLE
add integration test for d1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2069,7 +2069,7 @@ dependencies = [
 
 [[package]]
 name = "worker"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "async-trait",
  "chrono",

--- a/worker-sandbox/Cargo.toml
+++ b/worker-sandbox/Cargo.toml
@@ -26,7 +26,7 @@ http = "0.2.8"
 regex = "1.5.6"
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
-worker = { path = "../worker", version = "0.0.15", features= ["queue"] }
+worker = { path = "../worker", version = "0.0.16", features= ["queue"] }
 futures-channel = "0.3.21"
 futures-util = { version = "0.3.21", default-features = false }
 rand = "0.8.5"

--- a/worker-sandbox/tests/d1.rs
+++ b/worker-sandbox/tests/d1.rs
@@ -1,56 +1,115 @@
-use reqwest::blocking::Body;
+use worker_sandbox::{CreatePerson, Person};
 
-use crate::util::{expect_wrangler, post_return_err};
+use crate::util::{expect_wrangler, get, post, delete};
 
 mod util;
 
-fn post_exec_and_expect<T: Into<Body>>(query: T, expected: u32) {
-    let response = post_return_err(&format!("d1/exec"), |r| r.body(query.into())).unwrap();
-    let status = response.status();
-    let body = response.text().unwrap();
-    if status.is_success() {
-        let parsed = str::parse::<u32>(&body.clone());
-        assert!(parsed.is_ok());
-        assert_eq!(expected, parsed.unwrap());
-    } else {
-        let err = body.clone();
-        eprintln!("Error received: {}", err);
-        panic!("Error received from request.")
-    }
+fn drop_table() {
+    let response = post("d1/exec", |rb| rb.body("drop table if exists people;"));
+
+    assert!(response.status().is_success());
 }
 
-// #[test]
-// fn d1_exec_version() {
-//     expect_wrangler();
-//     post_exec_and_expect("PRAGMA schema_version", u32::MAX);
-// }
+fn create_table() {
+    let query = "CREATE TABLE IF NOT EXISTS people ( \
+            id INTEGER PRIMARY KEY, \
+            name TEXT NOT NULL, \
+            age INTEGER NOT NULL)";
+    let response = post("d1/exec", |rb| rb.body(query));
+    assert!(response.status().is_success());
+}
+
+fn setup() {
+    drop_table();
+    create_table();
+}
 
 #[test]
 fn d1_create_table() {
     expect_wrangler();
-    post_exec_and_expect(
-        "CREATE TABLE IF NOT EXISTS people ( \
-            person_id INTEGER PRIMARY KEY, \
-            name TEXT NOT NULL, \
-            age INTEGER NOT NULL)",
-        1,
-    );
+    setup();
 }
 
 #[test]
-fn d1_insert_data() {
+fn d1_insert_prepare_first() {
     expect_wrangler();
-    d1_create_table();
-    post_exec_and_expect(
-        "INSERT OR IGNORE INTO people \
-            (thing_id, title, description) \
-            VALUES \
-            (1, 'Freddie Pearce', 26), \
-            (2, 'Wynne Ogley', 67), \
-            (3, 'Dorian Fischer', 19), \
-            (4, 'John Smith', 92), \
-            (5, 'Magaret Willamson', 54), \
-            (6, 'Ryan Upton', 21),",
-        1,
-    );
+    setup();
+    let person = create_person();
+
+    assert_eq!("Ada LoveLace", person.name);
+    assert_eq!(32, person.age);
 }
+
+#[test]
+fn d1_select_prepare_all() {
+    expect_wrangler();
+    setup();
+    let person = create_person();
+
+    let response = get("d1/people", |rb| rb);
+    let people: Vec<Person> = serde_json::from_str(response.text().unwrap().as_str()).unwrap();
+
+    assert!(people.contains(&person));
+}
+
+#[test]
+fn d1_select_prepare_first() {
+    expect_wrangler();
+    setup();
+    let person = create_person();
+
+    let response = get(format!("d1/people/{}", person.id).as_str(), |rb| rb);
+    let person_by_id: Person = serde_json::from_str(response.text().unwrap().as_str()).unwrap();
+
+    assert_eq!(person_by_id, person);
+}
+
+#[test]
+fn d1_delete_prepare_run() {
+    expect_wrangler();
+    setup();
+    let person = create_person();
+    let response = delete(format!("d1/people/{}", person.id).as_str(), |rb| rb);
+
+    if response.status().is_success() {
+        let response = get("d1/people", |rb| rb);
+        let people: Vec<Person> = serde_json::from_str(response.text().unwrap().as_str()).unwrap();
+        assert!(!people.contains(&person));
+    } else {
+        panic!("failed to delete person");
+    }
+}
+
+#[test]
+fn d1_update_prepare() {
+    expect_wrangler();
+    setup();
+    let og_person = create_person();
+
+    let update_person = Person {
+        id: og_person.id,
+        age: 100,
+        name: "Ada L".to_string()
+    };
+
+    post(format!("d1/people/{}", update_person.id).as_str(), |rb| rb.body(serde_json::to_string(&update_person).unwrap()));
+
+    let response = get("d1/people", |rb| rb);
+    let people: Vec<Person> = serde_json::from_str(response.text().unwrap().as_str()).unwrap();
+    assert!(people.contains(&update_person));
+    assert!(!people.contains(&og_person));
+}
+
+fn create_person() -> Person {
+    let new_person = CreatePerson {
+        name: "Ada LoveLace".to_string(),
+        age: 32,
+    };
+    let response = post("d1/people", |rb| rb.body(serde_json::to_string(&new_person).unwrap()));
+    let person: Person = serde_json::from_str(response.text().unwrap().as_str()).unwrap();
+    person
+}
+
+
+
+

--- a/worker-sandbox/tests/util.rs
+++ b/worker-sandbox/tests/util.rs
@@ -46,18 +46,6 @@ pub fn post(endpoint: &str, builder_fn: impl FnOnce(RequestBuilder) -> RequestBu
         .unwrap_or_else(|_| panic!("received invalid status code for {}", endpoint))
 }
 
-pub fn post_return_err(
-    endpoint: &str,
-    builder_fn: impl FnOnce(RequestBuilder) -> RequestBuilder,
-) -> reqwest::Result<Response> {
-    expect_wrangler();
-
-    let builder = Client::new().post(format!("http://127.0.0.1:8787/{endpoint}"));
-    let builder = builder_fn(builder);
-
-    builder.send()
-}
-
 #[allow(dead_code)]
 pub fn put(endpoint: &str, builder_fn: impl FnOnce(RequestBuilder) -> RequestBuilder) -> Response {
     expect_wrangler();

--- a/worker-sys/src/types/durable_object/state.rs
+++ b/worker-sys/src/types/durable_object/state.rs
@@ -12,4 +12,7 @@ extern "C" {
 
     #[wasm_bindgen(method, getter)]
     pub fn storage(this: &DurableObjectState) -> DurableObjectStorage;
+
+    #[wasm_bindgen(method, js_name=waitUntil)]
+    pub fn wait_until(this: &DurableObjectState, promise: &js_sys::Promise);
 }

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "worker"
-version = "0.0.15"
+version = "0.0.16"
 authors = ["Cloudflare Workers Team <workers@cloudflare.com>"]
 repository = "https://github.com/cloudflare/workers-rs"
 edition = "2018"

--- a/worker/src/context.rs
+++ b/worker/src/context.rs
@@ -43,3 +43,9 @@ impl Context {
         self.inner.pass_through_on_exception()
     }
 }
+
+impl AsRef<JsContext> for Context {
+    fn as_ref(&self) -> &JsContext {
+        &self.inner
+    }
+}


### PR DESCRIPTION
I've started to add some integration tests for D1  Support.  

The tests cover.
* first
* run
* all
* exec

I'm wondering about [raw](https://github.com/cloudflare/workers-rs/pull/270/files#diff-235d2196421bbaa77addaf3acf14c6d244e02491e8b60f1e23a9552c28535826R175).  I don't think it should take a generic type T because consumers are unlikely going to write a select statement where all the types are the same.  In the people case, `select * from people`.raw() will cause a type error between the String and Integer types. Perhaps, it should be a String rather than T?

Let me know your thoughts on all this, and then I will see where more might be needed.

